### PR TITLE
Fixed bug in example which would crash client if player can't be seen.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ bot.once('spawn', () => {
   
     if (username === bot.username) return
 
-    const target = bot.players[username].entity
+    const target = bot.players[username]?.entity
     if (message === 'come') {
       if (!target) {
         bot.chat('I don\'t see you !')


### PR DESCRIPTION
If the bot hasn't loaded the player, such as being too far away or on certain server proxies, the bot would crash when trying to find the entity.