### PR TITLE
Tool selection improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,32 +13,20 @@ const THINK_TIMEOUT = 40 // ms
 function inject (bot) {
   bot.pathfinder = {}
 
-  function itemIsTool (item) {
-    // tools are named material_toolname eg wooden_pickaxe
-    const itemNameSplit = item.name.split('_')
-    if (itemNameSplit.length === 2) {
-      const toolNames = ['sword', 'axe', 'pickaxe', 'shovel']
-      return toolNames.includes(itemNameSplit[1])
-    }
-    return false
-  }
-
   bot.pathfinder.bestHarvestTool = function (block) {
-    if (block.name === 'air') return null
-
-    const availableTools = bot.inventory.items().filter(itemIsTool)
+    const availableTools = bot.inventory.items()
     const effects = bot.entity.effects
 
     let fastest = Number.MAX_VALUE
     let bestTool = null
-    availableTools.forEach(tool => {
+    for (const tool of availableTools) {
       const enchants = (tool && tool.nbt) ? nbt.simplify(tool.nbt).Enchantments : []
       const digTime = block.digTime(tool ? tool.type : null, false, false, false, enchants, effects)
       if (digTime < fastest) {
         fastest = digTime
         bestTool = tool
       }
-    })
+    }
 
     return bestTool
   }

--- a/index.js
+++ b/index.js
@@ -13,12 +13,12 @@ const THINK_TIMEOUT = 40 // ms
 function inject (bot) {
   bot.pathfinder = {}
 
-  function itemIsTool(item) {
+  function itemIsTool (item) {
     // tools are named material_toolname eg wooden_pickaxe
-    let itemNameSplit = item.name.split('_')
-    if(itemNameSplit.length === 2) {
+    const itemNameSplit = item.name.split('_')
+    if (itemNameSplit.length === 2) {
       const toolNames = ['sword', 'axe', 'pickaxe', 'shovel']
-      return toolNames.includes(itemNameSplit[1]);
+      return toolNames.includes(itemNameSplit[1])
     }
     return false
   }
@@ -26,7 +26,7 @@ function inject (bot) {
   bot.pathfinder.bestHarvestTool = function (block) {
     if (block.name === 'air') return null
 
-    const availableTools = bot.inventory.items().filter(itemIsTool);
+    const availableTools = bot.inventory.items().filter(itemIsTool)
     const effects = bot.entity.effects
 
     let fastest = Number.MAX_VALUE
@@ -34,13 +34,12 @@ function inject (bot) {
     availableTools.forEach(tool => {
       const enchants = (tool && tool.nbt) ? nbt.simplify(tool.nbt).Enchantments : []
       const digTime = block.digTime(tool ? tool.type : null, false, false, false, enchants, effects)
-      if(digTime < fastest) {
+      if (digTime < fastest) {
         fastest = digTime
         bestTool = tool
       }
     })
-    
-    console.log(block.name, bestTool.name);
+
     return bestTool
   }
 

--- a/index.js
+++ b/index.js
@@ -12,16 +12,41 @@ const THINK_TIMEOUT = 40 // ms
 function inject (bot) {
   bot.pathfinder = {}
 
-  bot.pathfinder.bestHarvestTool = function (block) {
-    const items = bot.inventory.items()
-    for (const i in block.harvestTools) {
-      const id = parseInt(i, 10)
-      for (const j in items) {
-        const item = items[j]
-        if (item.type === id) return item
-      }
+  function bestToolOfTypeInInventory (bot, toolname, materials) {
+    const tools = materials.map(x => x + '_' + toolname)
+    for (let i = tools.length - 1; i >= 0; i--) {
+      const tool = tools[i]
+      const matches = bot.inventory.items().filter(item => item.name === tool)
+      if (matches.length > 0) return matches[0]
     }
     return null
+  }
+
+  bot.pathfinder.bestHarvestTool = function (block) {
+    if (block.name === 'air') return null
+
+    const items = bot.inventory.items()
+    const harvestTools = block.harvestTools ? Object.keys(block.harvestTools).map(id => parseInt(id, 10)) : []
+    // sort by id, roughly equal to using the best available tool
+    const usableItems = items.filter(item => harvestTools.includes(item.type)).sort((a, b) => b.type - a.type)
+    if (usableItems.length > 0) return usableItems[0]
+
+    // Some blocks list no harvest tool, but can be mined quicker with a specific tool
+    // Available materials for tools, best to worst for speed according to https://minecraft.gamepedia.com/Tool#Best_tools
+    const materials = ['wooden', 'stone', 'iron', 'diamond', 'netherite', 'golden']
+    switch (block.material) {
+      case 'dirt':
+        return bestToolOfTypeInInventory(bot, 'shovel', materials)
+      case 'wood':
+        return bestToolOfTypeInInventory(bot, 'axe', materials)
+      case 'plant':
+        return bestToolOfTypeInInventory(bot, 'sword', materials)
+      case 'rock':
+        return bestToolOfTypeInInventory(bot, 'pickaxe', materials)
+      case undefined:
+      default:
+        return null
+    }
   }
 
   bot.pathfinder.getPathTo = function (movements, goal, done, timeout) {


### PR DESCRIPTION
As per discussion on PR #19: Improved tool selection using `digTime`.

I'm open to suggestions on improving the new `itemIsTool` check, feels like there should be a better way to check than string comparisons, but I think it works as a first pass anyhow.

Tested with the `example/test.js` bot on `1.16.1` and seems to work