### PR TITLE
Exposed ThinkTimeout Variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ const Vec3 = require('vec3').Vec3
 const { PlayerState } = require('prismarine-physics')
 const nbt = require('prismarine-nbt')
 
-const THINK_TIMEOUT = 40 // ms
-
 function inject (bot) {
   bot.pathfinder = {}
+  
+  bot.pathfinder.thinkTimeout = 40 // ms
 
   bot.pathfinder.bestHarvestTool = function (block) {
     const availableTools = bot.inventory.items()
@@ -34,7 +34,7 @@ function inject (bot) {
   bot.pathfinder.getPathTo = function (movements, goal, done, timeout) {
     const p = bot.entity.position
     const start = new Move(p.x, p.y, p.z, movements.countScaffoldingItems(), 0)
-    done(new AStar(start, movements, goal, timeout || THINK_TIMEOUT).compute())
+    done(new AStar(start, movements, goal, timeout || bot.pathfinder.thinkTimeout).compute())
   }
 
   let stateMovements = null

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const nbt = require('prismarine-nbt')
 
 function inject (bot) {
   bot.pathfinder = {}
-  
+
   bot.pathfinder.thinkTimeout = 40 // ms
 
   bot.pathfinder.bestHarvestTool = function (block) {


### PR DESCRIPTION
Currently, there is no way to specify the timeout variable without directly editing the source files. This variable should be exposed to allow users to define their own timeouts.

The default value of 40ms only discovers roughly 250 nodes on my machine (and visits a mere 40), which is only useful in very short distances. (I think this part is slow as the interpreter needs some time to cache the code)

```js
{
  status: 'timeout',
  cost: 0,
  time: 40.84438499994576,
  visitedNodes: 43,
  generatedNodes: 262,
  path: []
}
```

I have many instances where I would like to specify much larger timeouts for very far distances, and this is simply not possible at current.