### PR TITLE
Add typing for events

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -262,13 +262,20 @@ declare module 'mineflayer-pathfinder' {
 
 	type Callback = (error?: Error) => void;
 
-	export interface ComputedPath {
-		status: 'noPath' | 'timeout' | 'success';
+	interface PathBase {
 		cost: number;
 		time: number;
 		visitedNodes: number;
 		generatedNodes: number;
 		path: Move[];
+	}
+
+	export interface ComputedPath extends PathBase {
+		status: 'noPath' | 'timeout' | 'success';
+	}
+
+	export interface PartiallyComputedPath extends PathBase {
+		status: 'noPath' | 'timeout' | 'success' | 'partial';
 	}
 
 	export interface XZCoordinates {
@@ -299,6 +306,18 @@ declare module 'mineflayer-pathfinder' {
 }
 
 declare module 'mineflayer' {
+	interface BotEvents {
+		goal_reached: (goal: Goal) => void;
+		path_update: (path: PartiallyComputedPath) => void;
+		goal_updated: (goal: Goal, dynamic: boolean) => void;
+		path_reset: (
+			reason: 'goal_updated' | 'movements_updated' |
+				'block_updated' | 'chunk_loaded' | 'goal_moved' | 'dig_error' |
+				'no_scaffolding_blocks' | 'place_error' | 'stuck'
+		) => void;
+		path_stop: () => void;
+	}
+
 	interface Bot {
 		pathfinder: Pathfinder
 	}


### PR DESCRIPTION
Some details:
- The events are added into the `BotEvents` interface of mineflayer. In mineflayer, `TypedEmitter<BotEvents>` is extended by `Bot`, so the event handlers automatically go into `Bot`.
- I notice that `ComputedPath` cannot have a `'partial'` status, which can show up in the argument of the `path_update` event, since the updated path may be not fully computed yet. I split `ComputedPath` into a `PathBase` containing all properties except `status`, and `ComputedPath` extending it while adding `status` back. A new `PartiallyComputedPath` extends `PathBase` with a larger set of `status`'s.

This may solve https://github.com/PrismarineJS/mineflayer-pathfinder/issues/178 more gracefully.