### PR TITLE
Pillar jumping bug fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -541,7 +541,7 @@ function inject (bot) {
       let canPlace = true
       if (placingBlock.jump) {
         bot.setControlState('jump', true)
-        canPlace = placingBlock.y + 1 < bot.entity.position.y
+        canPlace = placingBlock.y + 2.1 < bot.entity.position.y
       }
       if (canPlace) {
         if (!lockEquipItem.tryAcquire()) return
@@ -553,7 +553,7 @@ function inject (bot) {
             if (interactableBlocks.includes(refBlock.name)) {
               bot.setControlState('sneak', true)
             }
-            bot.placeBlock(refBlock, new Vec3(placingBlock.dx, placingBlock.dy, placingBlock.dz))
+            bot._placeBlockWithOptions(refBlock, new Vec3(placingBlock.dx, placingBlock.dy, placingBlock.dz), { swingArm: 'right', forceLook: true })
               .then(function () {
                 // Dont release Sneak if the block placement was not successful
                 bot.setControlState('sneak', false)


### PR DESCRIPTION
\- `bot.placeBlock(refBlock, new Vec3(placingBlock.dx, placingBlock.dy, placingBlock.dz))`
\+ `bot._placeBlockWithOptions(refBlock, new Vec3(placingBlock.dx, placingBlock.dy, placingBlock.dz), { swingArm: 'right', forceLook: true })`
Place the block immediately instead of waiting for our head to turn.

\- `canPlace = placingBlock.y + 1 < bot.entity.position.y`
\+ `canPlace = placingBlock.y + 2.1 < bot.entity.position.y`
Wait until we are above the block before trying to place it. (Minecraft measures blocks from the lower north-west corner. 1 = top of original block. 2 = top of new block)

Only partially fixes #296.