### PR TITLE
Fix futility check

### DIFF
--- a/index.js
+++ b/index.js
@@ -476,6 +476,17 @@ function inject (bot) {
       return
     }
 
+    moveToNextNode();
+
+    // check for futility
+    // if we are digging we may take longer.
+    if (!digging && performance.now() - lastNodeTime > 3500) {
+      // should never take this long to go to the next node
+      resetpath('stuck')
+    }
+  }
+
+  function moveToNextNode () {
     let nextPoint = path[0]
     const p = bot.entity.position
 
@@ -626,12 +637,6 @@ function inject (bot) {
     } else {
       bot.setControlState('forward', false)
       bot.setControlState('sprint', false)
-    }
-
-    // check for futility
-    if (performance.now() - lastNodeTime > 3500) {
-      // should never take this long to go to the next node
-      resetPath('stuck')
     }
   }
 }


### PR DESCRIPTION
Many branches of the movement logic returned early skipping the futility check.
This sometimes results in the agent jumping up and down indefinitely instead of recalculating the path.

https://github.com/user-attachments/assets/b293c9e1-a24b-40d1-be4d-e7a2346e3e6d


https://github.com/user-attachments/assets/3f6c71ff-52f8-4680-b17b-c9b887a814e1

Ideally, we should avoid getting stuck in the first place, but getting stuck for 3.5 seconds is better than getting stuck forever.